### PR TITLE
add option to add a font from url

### DIFF
--- a/src/FontManager.ts
+++ b/src/FontManager.ts
@@ -125,11 +125,12 @@ export default class FontManager {
 	/**
 	 * Add a new font to the font map and download its preview characters
 	 */
-	public addFont(fontFamily: string, downloadPreview = true): void {
+	public addFont(fontFamily: string, downloadPreview = true, url = ''): void {
 		// @ts-ignore: Custom font does not need `categories`, `scripts` and `variants` attributes
 		const font: Font = {
 			family: fontFamily,
 			id: getFontId(fontFamily),
+      url
 		};
 		this.fonts.set(fontFamily, font);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,7 @@ export interface Font {
 	// Fields used by font-picker
 	family: string;
 	id: string;
+  url: string; // For fonts from custom url
 	category: Category;
 	scripts: Script[]; // Called "subsets" in Google Fonts API
 	variants: Variant[];


### PR DESCRIPTION
This adds the option to use fonts outside of Google, as described in [#17](https://github.com/samuelmeuli/font-picker/issues/17)

It needs some changes on `font-manager`.
I am doing a pull request there too.